### PR TITLE
Closing out M4 (#191)

### DIFF
--- a/pages/artists/[slug]/index.js
+++ b/pages/artists/[slug]/index.js
@@ -31,6 +31,17 @@ import SendMessageButton from '@/components/messaging/SendMessageButton'
 
 const PhotoGallery = dynamic(() => import("@/components/cards/card_photoGallery"), { ssr: false })
 
+function pickField(record, ...keys) {
+  for (const key of keys) {
+    const value = record?.[key]
+    if (value !== undefined && value !== null) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
 function stripHtmlTags(value) {
   return String(value || "")
     .replace(/<[^>]*>/g, " ")
@@ -100,10 +111,43 @@ const Artist = (props) => {
     og: { title: stripHtmlTags(props.artist.title), description: stripHtmlTags(props.artist.byline) },
   }
 
-  const listings = (props.listings || []).map((l) => ({
-    ...l,
-    artist: { ...(l.artist || {}), path: l.artist?.path || props.slug },
-  }))
+  const artistForHtmlRender = useMemo(() => {
+    if (!props.artist) {
+      return null
+    }
+
+    const titleRichtext = pickField(props.artist, "titleRichtext", "TitleRichtext")
+    const bylineRichtext = pickField(props.artist, "bylineRichtext", "BylineRichtext")
+    const statementRichtext = pickField(props.artist, "statementRichtext", "StatementRichtext")
+    const biographyRichtext = pickField(props.artist, "biographyRichtext", "BiographyRichtext")
+
+    return {
+      ...props.artist,
+      title: titleRichtext || props.artist.title,
+      byline: bylineRichtext || props.artist.byline,
+      statement: statementRichtext || props.artist.statement,
+      biography: biographyRichtext || props.artist.biography,
+    }
+  }, [props.artist])
+
+  const listings = useMemo(() => (props.listings || []).map((listing) => {
+    const titleRichtext = pickField(listing, "titleRichtext", "TitleRichtext")
+    const descriptionRichtext = pickField(listing, "descriptionRichtext", "DescriptionRichtext")
+    const artistTitleRichtext = pickField(listing?.artist, "titleRichtext", "TitleRichtext")
+    const artistBylineRichtext = pickField(listing?.artist, "bylineRichtext", "BylineRichtext")
+
+    return {
+      ...listing,
+      title: titleRichtext || listing?.title,
+      description: descriptionRichtext || listing?.description,
+      artist: {
+        ...(listing.artist || {}),
+        title: artistTitleRichtext || listing?.artist?.title,
+        byline: artistBylineRichtext || listing?.artist?.byline,
+        path: listing?.artist?.path || props.slug,
+      },
+    }
+  }), [props.listings, props.slug])
 
   const galleryItems = useMemo(() => (
     props.artist?.gallery?.galleryItems ||
@@ -198,11 +242,11 @@ const Artist = (props) => {
                   showContentGallery={false}
                   textRenderMode="html"
                   artist={{
-                    ...props.artist,
+                    ...artistForHtmlRender,
                     profilePic: props.profilePic,
                     images: props.profilePic?.url ? [props.profilePic.url] : [],
                     path: props.slug,
-                    since: props.artist?.applied,
+                    since: artistForHtmlRender?.applied,
                     panelSize: "full",
                   }}
                 />
@@ -272,7 +316,7 @@ const Artist = (props) => {
               <h2 className="text-2xl font-bold mb-4 border-b pb-2 text-primary">Artist Statement</h2>
               <div
                 dangerouslySetInnerHTML={{
-                  __html: sanitizeDefaultHtml(props.artist.statement || "No statement available."),
+                  __html: sanitizeDefaultHtml(artistForHtmlRender?.statement || "No statement available."),
                 }}
               />
             </div>

--- a/pages/blogs/[slug]/index.js
+++ b/pages/blogs/[slug]/index.js
@@ -27,6 +27,17 @@ import { PERMISSIONS } from "@/utils/permissions";
 import { hasPermission } from "@/utils/authHelpers";
 import { sanitizeDefaultHtml, sanitizeCardHtml } from "@/components/security/sanitize";
 
+function pickField(record, ...keys) {
+	for (const key of keys) {
+		const value = record?.[key];
+		if (value !== undefined && value !== null) {
+			return value;
+		}
+	}
+
+	return undefined;
+}
+
 
 
 function formatCompactNumber(value, fallback = 0) {
@@ -75,6 +86,11 @@ const BlogByslug = props => {
 	const { data: session } = useSession();
 	const [mounted, setMounted] = useState(false)
 	const blog = props.blog
+	const blogRichtext = {
+		title: pickField(blog, "titleRichtext", "TitleRichtext") || blog?.title || "",
+		byline: pickField(blog, "bylineRichtext", "BylineRichtext") || blog?.byline || "",
+		body: pickField(blog, "bodyRichtext", "BodyRichtext") || blog?.body || "",
+	}
 	const seoKeywords = `blog, post, article, ${blog.searchterms}`
 	const canonicalSlug = `blogs/${blog.path}`
 	const hasBlankCover = !blog?.image || blog.image === "/blank_image.png"
@@ -269,11 +285,11 @@ const BlogByslug = props => {
 
 				<div className="rounded-box border border-base-300 bg-base-200/40 p-4">
 					<h1 className="font-poiret text-5xl md:text-7xl shadow-text">
-						{stripHtmlTags(props.blog.title) || "Untitled"}
+						{stripHtmlTags(blogRichtext.title || props.blog.title) || "Untitled"}
 					</h1>
 					<div
 						className="font-fredoka pt-2"
-						dangerouslySetInnerHTML={{ __html: sanitizeCardHtml(props.blog.byline) }}
+						dangerouslySetInnerHTML={{ __html: sanitizeCardHtml(blogRichtext.byline || props.blog.byline) }}
 					></div>
 					<div className="font-baloo pt-2 text-xs shadow-dark">{props.blog.formattedCreated}</div>
 				</div>
@@ -337,7 +353,7 @@ const BlogByslug = props => {
 
 						<div
 							className="blog-rich-content font-fredoka rounded-box border border-base-300 bg-base-100 p-6 md:p-8 space-y-6"
-							dangerouslySetInnerHTML={{ __html: sanitizeDefaultHtml(addSectionAnchors(String(blog.body || ""))) }}
+							dangerouslySetInnerHTML={{ __html: sanitizeDefaultHtml(addSectionAnchors(String(blogRichtext.body || ""))) }}
 						>
 						</div>
 					</>

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -12,8 +12,232 @@ import React, { useState } from "react"
 import Link from "next/link"
 import getApiURL from "@/components/widgets/GetApiURL"
 import TagSEO from "@/components/TagSEO"
+import ArtistCardSmall from "@/components/cards/card_artist_small"
+import ListingCardSmall from "@/components/cards/card_listing_small"
 
-const SearchPage = ({ initialSearchTerm, results: initialResults = [] }) => {
+const ENTITY_TYPES = ["artist", "listing", "event", "user", "venue"]
+const SEARCH_TYPE_OPTIONS = ["all", ...ENTITY_TYPES]
+
+const SEARCH_ENDPOINTS = {
+	artist: "search/artist",
+	listing: "search/listing",
+	event: "search/event",
+	user: "search/user",
+	venue: "search/venue",
+}
+
+const SEARCH_TYPE_LABELS = {
+	all: "All",
+	artist: "Artists",
+	listing: "Listings",
+	event: "Events",
+	user: "Users",
+	venue: "Venues",
+}
+
+function buildEmptyResultsByType() {
+	return ENTITY_TYPES.reduce((acc, type) => {
+		acc[type] = []
+		return acc
+	}, {})
+}
+
+function getSearchTypes(searchType) {
+	if (searchType === "all") return ENTITY_TYPES
+	return ENTITY_TYPES.includes(searchType) ? [searchType] : ["artist"]
+}
+
+function getSearchApiBase(apiUrl) {
+	const normalized = String(apiUrl || "").replace(/\/+$/, "/")
+	return normalized.replace(/\/api\/$/i, "/")
+}
+
+async function fetchSearchResults(searchApiBase, type, queryText, limit = 20) {
+	const endpointPath = SEARCH_ENDPOINTS[type]
+	if (!endpointPath || !queryText) return []
+
+	const endpoint = `${searchApiBase}${endpointPath}?q=${encodeURIComponent(queryText)}&limit=${limit}`
+	const response = await fetch(endpoint)
+	if (!response.ok) {
+		throw new Error(`Search ${type} failed with status ${response.status}`)
+	}
+
+	const data = await response.json()
+	return Array.isArray(data) ? data : []
+}
+
+async function fetchArtistPathById(apiUrl, artistId) {
+	if (!artistId) return ""
+	try {
+		const response = await fetch(`${apiUrl}artist/byID/${artistId}`)
+		if (!response.ok) return ""
+		const artist = await response.json()
+		return artist?.path || ""
+	} catch {
+		return ""
+	}
+}
+
+async function attachArtistPathsToListings(apiUrl, listings, artistResults = []) {
+	if (!Array.isArray(listings) || listings.length === 0) return []
+
+	const artistPathById = new Map()
+	artistResults.forEach((artist) => {
+		const artistId = Number(artist?.artistID || artist?.artistId || 0)
+		if (artistId > 0 && artist?.path) {
+			artistPathById.set(artistId, artist.path)
+		}
+	})
+
+	const unresolvedArtistIds = [...new Set(
+		listings
+			.map((listing) => Number(listing?.artistID || listing?.artistId || 0))
+			.filter((artistId) => artistId > 0 && !artistPathById.has(artistId))
+	)]
+
+	if (unresolvedArtistIds.length > 0) {
+		const resolvedPaths = await Promise.all(
+			unresolvedArtistIds.map((artistId) => fetchArtistPathById(apiUrl, artistId))
+		)
+		resolvedPaths.forEach((artistPath, idx) => {
+			if (artistPath) {
+				artistPathById.set(unresolvedArtistIds[idx], artistPath)
+			}
+		})
+	}
+
+	return listings.map((listing) => {
+		const artistId = Number(listing?.artistID || listing?.artistId || 0)
+		const artistPath =
+			listing?.artist?.path ||
+			listing?.artistPath ||
+			listing?.artistpath ||
+			(artistId > 0 ? artistPathById.get(artistId) : "") ||
+			""
+
+		return {
+			...listing,
+			artistPath,
+			artist: {
+				...(listing.artist || {}),
+				path: artistPath,
+			},
+		}
+	})
+}
+
+function normalizeResults(data, searchType) {
+	if (!Array.isArray(data)) return []
+
+	return data.map((item, index) => {
+		if (searchType === "artist") {
+			const path = item.path || item.slug || ""
+			return {
+				key: item.artistID || item.artistid || `artist-${index}`,
+				href: path ? `/artists/${path}` : null,
+				label: item.byline || item.title || "Untitled artist",
+				canLink: Boolean(path),
+				cardData: {
+					...item,
+					path,
+				},
+			}
+		}
+
+		if (searchType === "listing") {
+			const listingPath = item.path || ""
+			const artistPath = item?.artist?.path || item.artistPath || item.artistpath || ""
+			const canLink = Boolean(listingPath && artistPath)
+			return {
+				key: item.listingID || item.listingid || `listing-${index}`,
+				href: canLink ? `/artists/${artistPath}/listings/${listingPath}` : null,
+				label: item.title || "Untitled listing",
+				canLink,
+				artistLabel: item?.artist?.title || item.artistTitle || `Artist #${item.artistID || item.artistId || "unknown"}`,
+				cardData: {
+					...item,
+					path: listingPath,
+					artist: {
+						...(item.artist || {}),
+						path: artistPath,
+					},
+				},
+			}
+		}
+
+		if (searchType === "event") {
+			const path = item.path || item.slug || ""
+			return {
+				key: item.eventID || item.eventid || `event-${index}`,
+				href: path ? `/events/regional/${path}` : "/events",
+				label: item.title || "Untitled event",
+				byline: item.byline || item.description || "",
+				canLink: Boolean(path),
+			}
+		}
+
+		if (searchType === "user") {
+			const name = [item.firstName, item.famName].filter(Boolean).join(" ").trim()
+			const username = item.username || ""
+			return {
+				key: item.userID || item.userid || `user-${index}`,
+				href: username ? `/portal/user/${username}/edit` : "/portal/user",
+				label: name || item.username || "Unknown user",
+				byline: item.emailOne || item.emailTwo || "",
+				canLink: true,
+			}
+		}
+
+		if (searchType === "venue") {
+			const slug = item.slug || item.path || ""
+			return {
+				key: item.venueID || item.venueid || `venue-${index}`,
+				href: slug ? `/portal/venue/${slug}` : "/portal/venue",
+				label: item.name || "Unnamed venue",
+				byline: item.byline || item.description || "",
+				canLink: true,
+			}
+		}
+
+		return {
+			key: `result-${index}`,
+			href: null,
+			label: "Unknown result",
+			canLink: false,
+		}
+	})
+}
+
+function normalizeResultsByType(rawByType) {
+	const normalized = buildEmptyResultsByType()
+	ENTITY_TYPES.forEach((type) => {
+		normalized[type] = normalizeResults(rawByType?.[type] || [], type)
+	})
+	return normalized
+}
+
+function hasAnyResults(resultsByType, selectedTypes) {
+	return selectedTypes.some((type) => (resultsByType[type] || []).length > 0)
+}
+
+function SearchResultSmallCard({ title, subtitle, href }) {
+	return (
+		<div className="card bg-base-100 border border-base-300 shadow-sm">
+			<div className="card-body p-4">
+				{href ? (
+					<Link href={href} className="card-title text-primary hover:underline text-base leading-tight">
+						{title}
+					</Link>
+				) : (
+					<p className="card-title text-base leading-tight">{title}</p>
+				)}
+				{subtitle ? <p className="text-sm text-base-content/70 line-clamp-2">{subtitle}</p> : null}
+			</div>
+		</div>
+	)
+}
+
+const SearchPage = ({ initialSearchTerm, searchType: initialSearchType = "all", resultsByType: initialResultsByType }) => {
 	const pageMetaData = {
 		title: "Search",
 		description: "Search artists, listings, and related content across Platform.",
@@ -26,30 +250,69 @@ const SearchPage = ({ initialSearchTerm, results: initialResults = [] }) => {
 	}
 
 	const [searchTerm, setSearchTerm] = useState(initialSearchTerm || "")
-	const [searchType, setSearchType] = useState("artist")
+	const [searchType, setSearchType] = useState(initialSearchType)
 	const [orderBy, setOrderBy] = useState("relevance")
-	const [results, setResults] = useState(initialResults)
+	const [resultsByType, setResultsByType] = useState(normalizeResultsByType(initialResultsByType || buildEmptyResultsByType()))
+	const [isLoading, setIsLoading] = useState(false)
+	const [searchError, setSearchError] = useState("")
 
 	const handleSearch = async () => {
+		const trimmedSearchTerm = searchTerm.trim()
+		if (!trimmedSearchTerm) {
+			setResultsByType(buildEmptyResultsByType())
+			setSearchError("")
+			return
+		}
+
 		const api_url = getApiURL()
-		let endpoint = `${api_url}utility_search/search?keyword=${searchTerm}`
+		const searchApiBase = getSearchApiBase(api_url)
+		const typesToSearch = getSearchTypes(searchType)
+		const nextRawResults = buildEmptyResultsByType()
+		const nextResults = buildEmptyResultsByType()
+		setSearchError("")
+		setIsLoading(true)
+
 		try {
-			const res = await fetch(endpoint)
-			if (!res.ok) {
-				throw new Error(`HTTP error! status: ${res.status}`)
+			const settled = await Promise.allSettled(
+				typesToSearch.map((type) => fetchSearchResults(searchApiBase, type, trimmedSearchTerm, 30))
+			)
+
+			settled.forEach((result, idx) => {
+				const type = typesToSearch[idx]
+				if (result.status === "fulfilled") {
+					nextRawResults[type] = result.value
+				}
+			})
+
+			if (typesToSearch.includes("listing")) {
+				nextRawResults.listing = await attachArtistPathsToListings(api_url, nextRawResults.listing, nextRawResults.artist)
 			}
-			const data = await res.json()
-			console.log("Search results:", data) // Log the JSON response
-			setResults(data)
+
+			typesToSearch.forEach((type) => {
+				nextResults[type] = normalizeResults(nextRawResults[type], type)
+			})
+
+			if (settled.some((entry) => entry.status === "rejected")) {
+				setSearchError("Some results could not be loaded. Try narrowing by type.")
+			}
+
+			setResultsByType(nextResults)
 		} catch (error) {
 			console.error("An error has occurred with your search request: ", error)
+			setResultsByType(buildEmptyResultsByType())
+			setSearchError("Search request failed. Please try again.")
+		} finally {
+			setIsLoading(false)
 		}
 	}
+
+	const visibleTypes = getSearchTypes(searchType)
+	const hasResults = hasAnyResults(resultsByType, visibleTypes)
 
 	return (
 		<div className="p-4">
 			<TagSEO metadataProp={pageMetaData} canonicalSlug="search" />
-			<h1 className="text-2xl font-bold mb-4">Search Page</h1>
+			<h1 className="text-2xl font-bold mb-4">Search</h1>
 			<div className="flex flex-col gap-4 mb-6">
 				<input
 					type="text"
@@ -63,8 +326,11 @@ const SearchPage = ({ initialSearchTerm, results: initialResults = [] }) => {
 					onChange={(e) => setSearchType(e.target.value)}
 					className="select select-bordered w-full max-w-md"
 				>
-					<option value="artist">Artist</option>
-					<option value="listing">Listing</option>
+					{SEARCH_TYPE_OPTIONS.map((type) => (
+						<option key={type} value={type}>
+							{SEARCH_TYPE_LABELS[type]}
+						</option>
+					))}
 				</select>
 				<select
 					value={orderBy}
@@ -75,30 +341,77 @@ const SearchPage = ({ initialSearchTerm, results: initialResults = [] }) => {
 					<option value="date">Date</option>
 					<option value="popularity">Popularity</option>
 				</select>
-				<button onClick={handleSearch} className="btn btn-primary w-full max-w-md">
-					Search
+				<button onClick={handleSearch} className="btn btn-primary w-full max-w-md" disabled={isLoading}>
+					{isLoading ? "Searching..." : "Search"}
 				</button>
 			</div>
+			{searchError ? (
+				<div className="alert alert-warning mb-4">
+					<span>{searchError}</span>
+				</div>
+			) : null}
 			<div>
 				<h2 className="text-xl font-semibold mb-4">Results</h2>
-				{results.length > 0 ? (
-					<ul className="list-disc pl-5">
-						{results.map((result, index) => (
-							<li key={index} className="mb-2">
-								{result.artistID ? (
-									<Link href={`/artists/${result.path}`}>
-										<a className="link link-primary">{result.byline}</a>
-									</Link>
-								) : (
-									<Link href={`/listings/${result.listingID}`}>
-										<a className="link link-primary">{result.title}</a>
-									</Link>
-								)}
-							</li>
-						))}
-					</ul>
-				) : (
+				{!hasResults ? (
 					<p className="text-base-content/60">No results found</p>
+				) : (
+					<div className="space-y-8">
+						{visibleTypes.map((type) => {
+							const items = resultsByType[type] || []
+							if (items.length === 0) return null
+
+							return (
+								<section key={type} className="space-y-4">
+									<div className="flex items-center justify-between border-b border-base-300 pb-2">
+										<h3 className="text-lg font-semibold">{SEARCH_TYPE_LABELS[type]}</h3>
+										<span className="badge badge-ghost">{items.length}</span>
+									</div>
+
+									{type === "artist" ? (
+										<div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+											{items.map((item) => (
+												item?.cardData?.path ? (
+													<ArtistCardSmall key={item.key} artist={item.cardData} />
+												) : (
+													<SearchResultSmallCard
+														key={item.key}
+														title={item.label}
+														subtitle={item?.cardData?.title || "Artist"}
+														href={item.href}
+													/>
+												)
+											))}
+										</div>
+									) : null}
+
+									{type === "listing" ? (
+										<div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+											{items.map((item) => (
+												item.canLink ? (
+													<ListingCardSmall key={item.key} listing={item.cardData} textRenderMode="html" />
+												) : (
+													<SearchResultSmallCard
+														key={item.key}
+														title={item.label}
+														subtitle={`Artist: ${item.artistLabel}`}
+														href={item.href || (item?.cardData?.artist?.path ? `/artists/${item.cardData.artist.path}` : null)}
+													/>
+												)
+											))}
+										</div>
+									) : null}
+
+									{type !== "artist" && type !== "listing" ? (
+										<div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+											{items.map((item) => (
+												<SearchResultSmallCard key={item.key} title={item.label} subtitle={item.byline} href={item.href} />
+											))}
+										</div>
+									) : null}
+								</section>
+							)
+						})}
+					</div>
 				)}
 			</div>
 		</div>
@@ -107,33 +420,53 @@ const SearchPage = ({ initialSearchTerm, results: initialResults = [] }) => {
 
 SearchPage.getInitialProps = async function ({ query }) {
 	const api_url = getApiURL()
-	let data = []
+	const initialResultsByType = buildEmptyResultsByType()
 	let status = 200
 	const searchTerm = query.term || ""
+	const searchType = query.type || "all"
+	const trimmedSearchTerm = String(searchTerm).trim()
+	const typesToSearch = getSearchTypes(searchType)
+	const searchApiBase = getSearchApiBase(api_url)
 
 	if (process.env.DEBUG === "true") {
-		console.log("Artist data fetch starting via API: \n " + api_url + "utility_search/search?keyword=" + searchTerm)
+		console.log("Search fetch starting via API for types: ", typesToSearch.join(", "))
 	}
 
 	try {
-		const res = await fetch(`${api_url}utility_search/search?keyword=${searchTerm}`)
-		status = res.status
-		if (!res.ok) {
-			throw new Error(`HTTP error! status: ${status}`)
+		if (trimmedSearchTerm) {
+			const settled = await Promise.allSettled(
+				typesToSearch.map((type) => fetchSearchResults(searchApiBase, type, trimmedSearchTerm, 30))
+			)
+
+			settled.forEach((result, idx) => {
+				const type = typesToSearch[idx]
+				if (result.status === "fulfilled") {
+					initialResultsByType[type] = result.value
+				} else {
+					status = 206
+				}
+			})
+
+			if (typesToSearch.includes("listing")) {
+				initialResultsByType.listing = await attachArtistPathsToListings(api_url, initialResultsByType.listing, initialResultsByType.artist)
+			}
 		}
-		data = await res.json()
-		console.log("Initial search results:", data) // Log the JSON response
 	} catch (error) {
-		console.error("An error has occurred with your artist fetch request: ", error)
+		console.error("An error has occurred with your search fetch request: ", error)
+		status = 500
 	}
 
 	if (process.env.DEBUG === "true") {
-		console.log(`Artist data fetched. Count: ${data.length}`)
+		console.log("Search counts by type:", ENTITY_TYPES.reduce((acc, type) => {
+			acc[type] = initialResultsByType[type].length
+			return acc
+		}, {}))
 	}
 
 	return {
 		initialSearchTerm: searchTerm,
-		results: data,
+		resultsByType: initialResultsByType,
+		searchType,
 		status: status,
 	}
 }

--- a/pages/vendor/[slug]/index.js
+++ b/pages/vendor/[slug]/index.js
@@ -2,11 +2,23 @@ import Link from "next/link"
 import { useEffect, useMemo, useState } from "react"
 
 import getApiURL from "@/components/widgets/GetApiURL"
+import { sanitizeCardHtml, sanitizeDefaultHtml, stripHtmlText } from "@/components/security/sanitize"
 
 const apiUrl = getApiURL()
 
 function normalizeSlug(value) {
   return String(value || "").trim().toLowerCase()
+}
+
+function pickField(record, ...keys) {
+  for (const key of keys) {
+    const value = record?.[key]
+    if (value !== undefined && value !== null) {
+      return value
+    }
+  }
+
+  return undefined
 }
 
 function splitMedia(files = []) {
@@ -29,6 +41,9 @@ export default function VendorProfilePage({ vendor }) {
   const vendorName = String(vendor?.companyName || vendor?.CompanyName || "Vendor")
   const vendorNotes = String(vendor?.notesOnVendors || vendor?.NotesOnVendors || "")
   const contractNotes = String(vendor?.notesOnContracts || vendor?.NotesOnContracts || "")
+  const vendorNameRichtext = pickField(vendor, "companyNameRichtext", "CompanyNameRichtext") || vendorName
+  const vendorNotesRichtext = pickField(vendor, "notesOnVendorsRichtext", "NotesOnVendorsRichtext") || vendorNotes
+  const contractNotesRichtext = pickField(vendor, "notesOnContractsRichtext", "NotesOnContractsRichtext") || contractNotes
   const mediaPrefix = useMemo(() => (
     vendorId > 0 ? `platformpics/vendorcontent/${vendorId}/` : ""
   ), [vendorId])
@@ -80,7 +95,10 @@ export default function VendorProfilePage({ vendor }) {
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 md:py-12 space-y-6">
       <div className="flex items-center justify-between gap-2 flex-wrap">
-        <h1 className="text-3xl font-bold">{vendorName}</h1>
+        <h1
+          className="text-3xl font-bold"
+          dangerouslySetInnerHTML={{ __html: sanitizeCardHtml(vendorNameRichtext) }}
+        />
         <Link href="/search" className="btn btn-sm btn-outline">Back to Search</Link>
       </div>
 
@@ -95,21 +113,34 @@ export default function VendorProfilePage({ vendor }) {
           <h2 className="text-xl font-semibold">Vendor Profile</h2>
           <p className="text-sm text-base-content/70">This basic profile uses the same vendor API-backed fields configured during onboarding.</p>
           <div className="text-sm space-y-2">
-            <div><span className="font-semibold">Company:</span> {vendorName}</div>
+            <div>
+              <span className="font-semibold">Company:</span>{" "}
+              <span dangerouslySetInnerHTML={{ __html: sanitizeCardHtml(vendorNameRichtext) }} />
+            </div>
             <div><span className="font-semibold">POC:</span> {vendor?.pocName || vendor?.POCName || "Not listed"}</div>
             <div><span className="font-semibold">POC Email:</span> {vendor?.pocEmail || vendor?.POCEmail || "Not listed"}</div>
             <div><span className="font-semibold">POC Phone:</span> {vendor?.pocPhone || vendor?.POCPhone || "Not listed"}</div>
             <div><span className="font-semibold">Contract Link:</span> {vendor?.linkToContract || vendor?.LinkToContract || "Not listed"}</div>
           </div>
-          {vendorNotes ? <p className="text-sm whitespace-pre-wrap">{vendorNotes}</p> : null}
-          {contractNotes ? <p className="text-sm whitespace-pre-wrap text-base-content/70">{contractNotes}</p> : null}
+          {vendorNotesRichtext ? (
+            <div
+              className="text-sm"
+              dangerouslySetInnerHTML={{ __html: sanitizeDefaultHtml(vendorNotesRichtext) }}
+            />
+          ) : null}
+          {contractNotesRichtext ? (
+            <div
+              className="text-sm text-base-content/70"
+              dangerouslySetInnerHTML={{ __html: sanitizeDefaultHtml(contractNotesRichtext) }}
+            />
+          ) : null}
         </div>
 
         <div className="rounded-box border border-base-300 bg-base-100 shadow p-4">
           <h3 className="font-semibold mb-3">Profile Image</h3>
           <img
             src={profile?.url || "/blank_image.png"}
-            alt={`${vendorName} profile`}
+            alt={`${stripHtmlText(vendorNameRichtext || vendorName)} profile`}
             className="w-full h-56 object-cover rounded-box border border-base-300"
           />
         </div>

--- a/pages/venue/[slug]/index.js
+++ b/pages/venue/[slug]/index.js
@@ -2,11 +2,23 @@ import Link from "next/link"
 import { useEffect, useMemo, useState } from "react"
 
 import getApiURL from "@/components/widgets/GetApiURL"
+import { sanitizeCardHtml, stripHtmlText } from "@/components/security/sanitize"
 
 const apiUrl = getApiURL()
 
 function normalizeSlug(value) {
   return String(value || "").trim().toLowerCase()
+}
+
+function pickField(record, ...keys) {
+  for (const key of keys) {
+    const value = record?.[key]
+    if (value !== undefined && value !== null) {
+      return value
+    }
+  }
+
+  return undefined
 }
 
 function splitMedia(files = []) {
@@ -27,6 +39,7 @@ export default function VenueProfilePage({ venue }) {
 
   const venueId = Number(venue?.venueID || venue?.VenueID || 0)
   const venueName = String(venue?.name || venue?.Name || "Venue")
+  const venueNameRichtext = pickField(venue, "nameRichtext", "NameRichtext") || venueName
   const mediaPrefix = useMemo(() => (
     venueId > 0 ? `platformpics/venuecontent/${venueId}/` : ""
   ), [venueId])
@@ -78,7 +91,10 @@ export default function VenueProfilePage({ venue }) {
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 md:py-12 space-y-6">
       <div className="flex items-center justify-between gap-2 flex-wrap">
-        <h1 className="text-3xl font-bold">{venueName}</h1>
+        <h1
+          className="text-3xl font-bold"
+          dangerouslySetInnerHTML={{ __html: sanitizeCardHtml(venueNameRichtext) }}
+        />
         <Link href="/search" className="btn btn-sm btn-outline">Back to Search</Link>
       </div>
 
@@ -93,7 +109,10 @@ export default function VenueProfilePage({ venue }) {
           <h2 className="text-xl font-semibold">Venue Profile</h2>
           <p className="text-sm text-base-content/70">This basic venue page stays aligned with the lightweight venue API model while gallery and contact data are linked separately.</p>
           <div className="text-sm space-y-2">
-            <div><span className="font-semibold">Venue:</span> {venueName}</div>
+            <div>
+              <span className="font-semibold">Venue:</span>{" "}
+              <span dangerouslySetInnerHTML={{ __html: sanitizeCardHtml(venueNameRichtext) }} />
+            </div>
             <div><span className="font-semibold">Published:</span> {venue?.isPublished || venue?.IsPublished ? "Yes" : "No"}</div>
             <div><span className="font-semibold">Address FK:</span> {venue?.addressID || venue?.AddressID || "Not linked"}</div>
             <div><span className="font-semibold">Phone FK:</span> {venue?.phoneContactID || venue?.PhoneContactID || "Not linked"}</div>
@@ -105,7 +124,7 @@ export default function VenueProfilePage({ venue }) {
           <h3 className="font-semibold mb-3">Profile Image</h3>
           <img
             src={profile?.url || "/blank_image.png"}
-            alt={`${venueName} profile`}
+            alt={`${stripHtmlText(venueNameRichtext || venueName)} profile`}
             className="w-full h-56 object-cover rounded-box border border-base-300"
           />
         </div>


### PR DESCRIPTION
* bloomscroll vines #42

* #62 saving changes to the artist workflow by splitting to components.

* #65 content updates after meeting with Javi.

* #87 - fixing up profile, cover, and gallery editor on artist

* artist forms:  update contact forms to handle primary entries and display order via the scope concept but without changes to api

* #62 refactor - vendor, venue, user modularlized to match recent artist refactor changes

* #62 Enhance onboarding forms with step completion indicators and bug alerts

- Added a step completion checklist to the ReviewAndPublishForm component.  Weakened on contact information entries due to bug in that form.
- Introduced a warning alert regarding unstable contact saving in PrivateContactsForm, PublicContactsForm, OrganizationPrimaryContactsStep, OrganizationPublicContactsStep, UserPrivateContactsStep, and other relevant components.
- Updated the JoinArtistIndexPage to include a new step for profile media and adjusted the step completion logic accordingly.
- Refactored contact filtering logic to improve clarity and maintainability across various join pages (artist, vendor, venue).
- Standardized back and continue button labels for better user experience.

* #62 bringing edits from recent work into the portal

- Consolidate venue editing steps into a modular structure using shared components.
- Introduce hooks for managing venue form state and loading contacts.
- Enhance slug registration and profile management with improved error handling.
- Implement progress tracking and step completion logic for a smoother user experience.
- Update server-side props to streamline data fetching and session management.

* #148 adding changes to banner back.  now will show uptime for dev or build number for prod. dismissing makes it go away for 5 minutes now, instead of next page load.

* Bugfix - page now scrolls to the top upon clicking a navigation link, instead of staying approximately the same distance down

* npm update

* bugfix- using getAIP() component instead of directly calling the env variable to stop dev warnings

* #62 refactor - removed social realtime context (mock) because the real thing is coming online and this legacy code is causing issues with the UX

* #176 notifications via signalR

-comments, reactions, and messages pop notifications for now.

* fix(signalr): re-register user notification group after reconnect

* bugfix: capture a single timestamp for banner use to fix a constant page refresh issue

* #176 testing notifications and adding notification based on comments.  refactored notification items into their own file for clarity's sake

* portal overhaul.  #62

- board portal created
- artist, user portals reworked heavily.

* integrating BE # 10 - search routes now working on manish's backend code and loading cards to display results

* #190 feat: add pickField utility function and enhance rich text handling for artist, blog, vendor, and venue profiles

---------