### PR TITLE
bugfix: making client side requests use the api proxy

### DIFF
--- a/libs/serverFetch.js
+++ b/libs/serverFetch.js
@@ -5,19 +5,26 @@
  * Automatically prepends the absolute backend URL so Next.js doesn't crash 
  * with "Invalid URL" when processing relative paths in getServerSideProps.
  * 
+ * When running on client-side, routes through Next.js proxy instead of direct backend.
+ * 
  * Usage: const res = await serverFetch(`/artist/${slug}`);
  */
 export async function serverFetch(path, options = {}) {
-    // 1. Grab the absolute URL from Azure / Docker, fallback to local Visual Studio
-    const backendApiUrl = (process.env.DOTNET_API_URL || 'https://localhost:7225/api').replace(/\/$/, "");
+    const isClient = typeof window !== 'undefined';
+    
+    // On client-side: use Next.js proxy at /api
+    // On server-side: use absolute backend URL (localhost or Azure)
+    const backendApiUrl = isClient 
+        ? '/api'  // Browser proxies through Next.js
+        : (process.env.DOTNET_API_URL || 'https://localhost:7225/api').replace(/\/$/, "");
 
-    // 2. Safely strip out the leading slash if the developer accidentally typed it
+    // Safely strip out the leading slash if the developer accidentally typed it
     const safePath = path.startsWith('/') ? path.substring(1) : path;
 
-    // 3. Construct the perfect Absolute URL (e.g. https://api.tags.com/api/artist/slug)
+    // Construct the fetch URL
     const fetchUrl = `${backendApiUrl}/${safePath}`;
 
-    // 4. Return the standard Node fetch promise
+    // Return the standard Node fetch promise
     return fetch(fetchUrl, options);
 }
 


### PR DESCRIPTION
Testing fix on prod - should resolve the error where the page only loads API data on F5 refresh instead of from a link. 