### PR TITLE
Bloomscroll Social Feed #235

### DIFF
--- a/components/feed/FeedComposer.js
+++ b/components/feed/FeedComposer.js
@@ -1,0 +1,114 @@
+/* This file is part of the Twisted Artists Guild project.
+
+ Copyright (C) 2025 Twisted Artists Guild
+
+ Licensed under the GNU General Public License v3.0
+ (https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+ This software comes with NO WARRANTY; see the license for details.
+
+ Open source - low-profit - human-first*/
+
+import { useState } from 'react';
+import { IoCreateOutline, IoCloseOutline } from 'react-icons/io5';
+
+const SHARE_TYPES = [
+    { type: null, label: 'General Post' },
+    { type: 'Listing', label: 'Share a Listing' },
+    { type: 'Artist', label: 'Share an Artist Profile' },
+    { type: 'Event', label: 'Share an Event' },
+];
+
+export default function FeedComposer({ session, onPostCreated }) {
+    const [showCompose, setShowCompose] = useState(false);
+    const [composeBody, setComposeBody] = useState('');
+    const [shareType, setShareType] = useState(null);
+    const [shareId, setShareId] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+
+    const handleSubmitPost = async (e) => {
+        e.preventDefault();
+        if (!session?.user?.id || (!composeBody.trim() && !shareType)) return;
+        setSubmitting(true);
+
+        try {
+            const res = await fetch('/api/Feed?authorUserId=' + session.user.id, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    body: composeBody.trim(),
+                    postType: shareType ? 'Share' + shareType : 'General',
+                    authorEntityType: null,
+                    authorEntityID: null,
+                    sharedEntityType: shareType || null,
+                    sharedEntityID: shareType && shareId ? parseInt(shareId) : null,
+                }),
+            });
+            if (res.ok) {
+                setComposeBody('');
+                setShareType(null);
+                setShareId('');
+                setShowCompose(false);
+                if (onPostCreated) onPostCreated();
+            }
+        } catch (err) {
+            console.error('Failed to create post', err);
+        }
+        setSubmitting(false);
+    };
+
+    return (
+        <div className="card bg-base-100 shadow-sm border border-base-300 mb-6">
+            <div className="card-body p-4">
+                {!showCompose ? (
+                    <button
+                        className="btn btn-ghost justify-start text-base-content/40 w-full text-left"
+                        onClick={() => setShowCompose(true)}
+                    >
+                        <IoCreateOutline /> What are you creating today?
+                    </button>
+                ) : (
+                    <form onSubmit={handleSubmitPost} className="space-y-3">
+                        <div className="flex justify-between items-center">
+                            <p className="font-bold text-sm">New Post</p>
+                            <button type="button" className="btn btn-ghost btn-xs btn-circle" onClick={() => setShowCompose(false)}><IoCloseOutline /></button>
+                        </div>
+                        <textarea
+                            className="textarea textarea-bordered w-full"
+                            rows={3}
+                            maxLength={5000}
+                            placeholder="Share your thoughts, your art, your chaos..."
+                            value={composeBody}
+                            onChange={(e) => setComposeBody(e.target.value)}
+                        />
+
+                        {/* Share type selector */}
+                        <div className="flex flex-wrap gap-2 items-center">
+                            <span className="text-xs font-medium text-base-content/50">Share:</span>
+                            {SHARE_TYPES.map(opt => (
+                                <button
+                                    key={opt.label}
+                                    type="button"
+                                    className={'badge badge-sm cursor-pointer ' + (shareType === opt.type ? 'badge-secondary' : 'badge-outline')}
+                                    onClick={() => { setShareType(opt.type); if (!opt.type) setShareId(''); }}
+                                >
+                                    {opt.label}
+                                </button>
+                            ))}
+                            {shareType && (
+                                <input type="number" min="1" className="input input-bordered input-xs w-24 font-mono" placeholder={shareType + ' ID'} value={shareId} onChange={(e) => setShareId(e.target.value)} />
+                            )}
+                        </div>
+
+                        <div className="flex justify-end gap-2">
+                            <button type="button" className="btn btn-ghost btn-sm" onClick={() => setShowCompose(false)}>Cancel</button>
+                            <button type="submit" className="btn btn-primary btn-sm" disabled={submitting || (!composeBody.trim() && !shareType)}>
+                                {submitting ? <span className="loading loading-spinner loading-sm"></span> : 'Post'}
+                            </button>
+                        </div>
+                    </form>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/components/feed/FeedPostCard.js
+++ b/components/feed/FeedPostCard.js
@@ -1,0 +1,197 @@
+/* This file is part of the Twisted Artists Guild project.
+
+ Copyright (C) 2025 Twisted Artists Guild
+
+ Licensed under the GNU General Public License v3.0
+ (https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+ This software comes with NO WARRANTY; see the license for details.
+
+ Open source - low-profit - human-first*/
+
+import { useState } from 'react';
+import { useSession } from 'next-auth/react';
+import Image from 'next/image';
+import Link from 'next/link';
+import ReportButton from '@/components/moderation/ReportButton';
+import ImpressionReactions from '@/components/social/ImpressionReactions';
+import { useImpressions, ImpressionTargetType } from '@/hooks/useImpressions';
+import { useComments, CommentTargetType } from '@/hooks/useComments';
+import { useCommentCount } from '@/hooks/useCommentCount';
+import SharedPreview from '@/components/feed/SharedPreview';
+import SharePopover from '@/components/feed/SharePopover';
+import FeedPostComments from '@/components/feed/FeedPostComments';
+import {
+    IoPersonOutline,
+    IoStorefrontOutline,
+    IoMusicalNotesOutline,
+    IoLocationOutline,
+    IoCalendarOutline,
+    IoImageOutline,
+    IoShareSocialOutline,
+    IoSparklesOutline,
+    IoChatbubbleOutline,
+    IoTrashOutline,
+} from 'react-icons/io5';
+import longDateOptions from '@/utils/longdateoptions';
+
+const ENTITY_ICONS = {
+    Artist: IoMusicalNotesOutline,
+    Vendor: IoStorefrontOutline,
+    Venue: IoLocationOutline,
+    Event: IoCalendarOutline,
+    Listing: IoImageOutline,
+};
+
+export default function FeedPostCard({ post }) {
+    const { data: session } = useSession();
+    const [showShare, setShowShare] = useState(false);
+    const [showComments, setShowComments] = useState(false);
+    const [postDeleted, setPostDeleted] = useState(false);
+    const EntityIcon = ENTITY_ICONS[post.authorEntityType] || IoPersonOutline;
+
+    const {
+        impressions,
+        loading: impressionsLoading,
+        toggleReaction
+    } = useImpressions(post.feedPostID, ImpressionTargetType.FEED_POST, true);
+
+    const {
+        commentCount: displayCount,
+        refetch: refetchCount
+    } = useCommentCount(post.feedPostID, CommentTargetType.FEED_POST, true);
+
+    const {
+        comments,
+        loading: commentsLoading,
+        addComment,
+        deleteComment,
+    } = useComments(post.feedPostID, CommentTargetType.FEED_POST, showComments);
+
+    const handleDeletePost = async () => {
+        if (!session?.user?.id) return;
+        if (!window.confirm('Delete this post?')) return;
+
+        try {
+            const res = await fetch('/api/Feed/' + post.feedPostID + '?userId=' + session.user.id, {
+                method: 'DELETE',
+            });
+            if (res.ok) {
+                setPostDeleted(true);
+            }
+        } catch (err) {
+            console.error('Failed to delete post', err);
+        }
+    };
+
+    if (postDeleted) return null;
+
+    return (
+        <article className="card bg-base-100 shadow-sm border border-base-300">
+            <div className="card-body p-4 gap-3">
+                {/* Author row */}
+                <div className="flex items-center gap-3">
+                    <div className="avatar">
+                        <div className="w-10 rounded-full bg-base-300">
+                            <Image
+                                src={post.authorImage || '/blank_image.png'}
+                                alt={post.authorName || 'User'}
+                                width={40} height={40}
+                                className="object-cover"
+                            />
+                        </div>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5">
+                            <span className="font-bold text-sm truncate">{post.authorName || 'Anonymous'}</span>
+                            {post.authorEntityName && (
+                                <Link href={post.authorEntityPath || '#'} className="badge badge-sm badge-primary badge-outline gap-1 truncate">
+                                    <EntityIcon className="text-xs" /> {post.authorEntityName}
+                                </Link>
+                            )}
+                        </div>
+                        <p className="text-xs text-base-content/50" suppressHydrationWarning>
+                            {new Date(post.createdAt).toLocaleDateString('en-US', longDateOptions)}
+                            {post.isSuggestedPost && <span className="ml-1 badge badge-xs badge-ghost gap-0.5"><IoSparklesOutline /> First post</span>}
+                        </p>
+                    </div>
+                    {session?.user && parseInt(session.user.id) === post.authorUserID && (
+                        <button
+                            className="btn btn-ghost btn-xs text-error"
+                            onClick={handleDeletePost}
+                            title="Delete post"
+                        >
+                            <IoTrashOutline />
+                        </button>
+                    )}
+                    <ReportButton targetType="FeedPost" targetId={post.feedPostID} targetURL={'/feed?post=' + post.feedPostID} />
+                </div>
+
+                {/* Body */}
+                {post.body && (
+                    <div className="text-sm text-base-content whitespace-pre-wrap leading-relaxed">
+                        {post.body_Plaintext || post.body}
+                    </div>
+                )}
+
+                {/* Attached image */}
+                {post.pictureURL && (
+                    <div className="relative w-full aspect-video rounded-box overflow-hidden bg-base-300">
+                        <Image src={post.pictureURL} alt="Post image" fill className="object-cover" />
+                    </div>
+                )}
+
+                {/* Shared entity preview */}
+                <SharedPreview preview={post.sharedEntityPreview} />
+
+                {/* Reactions */}
+                <div className="pt-1">
+                    {!impressionsLoading && impressions && impressions.length > 0 ? (
+                        <ImpressionReactions
+                            impressions={impressions}
+                            currentUser={session?.user || null}
+                            onToggle={toggleReaction}
+                            readOnly={false}
+                            size="sm"
+                            showDetails={false}
+                            targetId={post.feedPostID}
+                            targetType="feedpost"
+                        />
+                    ) : impressionsLoading ? (
+                        <div className="text-xs text-base-content/50">Loading reactions...</div>
+                    ) : null}
+                </div>
+
+                {/* Action bar */}
+                <div className="flex items-center gap-2 pt-1 border-t border-base-200">
+                    <button
+                        className="btn btn-ghost btn-xs gap-1"
+                        onClick={() => setShowComments(!showComments)}
+                    >
+                        <IoChatbubbleOutline />
+                        {displayCount} comment{displayCount !== 1 ? 's' : ''}
+                    </button>
+                    <span className="flex-1"></span>
+                    <div className="relative">
+                        <button className="btn btn-ghost btn-xs gap-1" onClick={() => setShowShare(!showShare)}>
+                            <IoShareSocialOutline /> Share
+                        </button>
+                        {showShare && <SharePopover post={post} onClose={() => setShowShare(false)} />}
+                    </div>
+                </div>
+
+                {/* Comments Section */}
+                {showComments && (
+                    <FeedPostComments
+                        comments={comments}
+                        commentsLoading={commentsLoading}
+                        session={session}
+                        addComment={addComment}
+                        deleteComment={deleteComment}
+                        refetchCount={refetchCount}
+                    />
+                )}
+            </div>
+        </article>
+    );
+}

--- a/components/feed/FeedPostComments.js
+++ b/components/feed/FeedPostComments.js
@@ -1,0 +1,182 @@
+/* This file is part of the Twisted Artists Guild project.
+
+ Copyright (C) 2025 Twisted Artists Guild
+
+ Licensed under the GNU General Public License v3.0
+ (https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+ This software comes with NO WARRANTY; see the license for details.
+
+ Open source - low-profit - human-first*/
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { IoTrashOutline } from 'react-icons/io5';
+import longDateOptions from '@/utils/longdateoptions';
+
+export default function FeedPostComments({ comments, commentsLoading, session, addComment, deleteComment, refetchCount }) {
+    const [newComment, setNewComment] = useState('');
+    const [commentSubmitting, setCommentSubmitting] = useState(false);
+
+    const handleSubmitComment = async (e) => {
+        e.preventDefault();
+        if (!session?.user?.id || !newComment.trim()) return;
+        setCommentSubmitting(true);
+
+        const result = await addComment({
+            content: newComment.trim(),
+            userId: parseInt(session.user.id),
+        });
+
+        if (result.success) {
+            setNewComment('');
+            refetchCount();
+        }
+        setCommentSubmitting(false);
+    };
+
+    const handleDeleteComment = async (commentId) => {
+        if (!session?.user?.id) return;
+        if (!window.confirm('Delete this comment?')) return;
+        await deleteComment(commentId, parseInt(session.user.id));
+        refetchCount();
+    };
+
+    return (
+        <div className="border-t border-base-200 pt-3 space-y-3">
+            {/* Comment input */}
+            {session?.user ? (
+                <form onSubmit={handleSubmitComment} className="flex gap-2">
+                    <div className="avatar">
+                        <div className="w-8 rounded-full bg-base-300">
+                            <Image
+                                src={session.user.image || '/blank_image.png'}
+                                alt="You"
+                                width={32} height={32}
+                                className="object-cover"
+                            />
+                        </div>
+                    </div>
+                    <div className="flex-1 flex gap-2">
+                        <input
+                            type="text"
+                            className="input input-bordered input-sm flex-1"
+                            placeholder="Write a comment..."
+                            maxLength={2000}
+                            value={newComment}
+                            onChange={(e) => setNewComment(e.target.value)}
+                        />
+                        <button
+                            type="submit"
+                            className="btn btn-primary btn-sm"
+                            disabled={commentSubmitting || !newComment.trim()}
+                        >
+                            {commentSubmitting ? <span className="loading loading-spinner loading-xs"></span> : 'Post'}
+                        </button>
+                    </div>
+                </form>
+            ) : (
+                <p className="text-xs text-base-content/50 text-center">
+                    <Link href="/api/auth/signin" className="link link-primary">Sign in</Link> to comment
+                </p>
+            )}
+
+            {/* Comments list */}
+            {commentsLoading ? (
+                <div className="flex justify-center py-3"><span className="loading loading-spinner loading-sm"></span></div>
+            ) : comments.length === 0 ? (
+                <p className="text-xs text-base-content/40 text-center py-2">No comments yet. Be the first!</p>
+            ) : (
+                <div className="space-y-3">
+                    {comments.map(comment => (
+                        <CommentItem
+                            key={comment.id}
+                            comment={comment}
+                            session={session}
+                            onDelete={handleDeleteComment}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function CommentItem({ comment, session, onDelete }) {
+    return (
+        <div className="flex gap-2">
+            <div className="avatar flex-shrink-0">
+                <div className="w-7 h-7 rounded-full bg-base-300 overflow-hidden relative">
+                    <Image
+                        src={comment.user?.image || '/blank_image.png'}
+                        alt={comment.user?.name || 'User'}
+                        fill
+                        sizes="28px"
+                        className="object-cover"
+                    />
+                </div>
+            </div>
+            <div className="flex-1 min-w-0">
+                <div className="bg-base-200 rounded-box px-3 py-2">
+                    <div className="flex items-center justify-between">
+                        <p className="font-bold text-xs">{comment.user?.name || 'Anonymous'}</p>
+                        {session?.user && parseInt(session.user.id) === comment.userId && (
+                            <button
+                                className="btn btn-ghost btn-xs text-error p-0 h-auto min-h-0"
+                                onClick={() => onDelete(comment.id)}
+                                title="Delete comment"
+                            >
+                                <IoTrashOutline className="text-sm" />
+                            </button>
+                        )}
+                    </div>
+                    <p className="text-sm text-base-content">{comment.content}</p>
+                </div>
+                <div className="flex gap-3 mt-0.5 px-1">
+                    <span className="text-xs text-base-content/40" suppressHydrationWarning>
+                        {new Date(comment.createdAt).toLocaleDateString('en-US', longDateOptions)}
+                    </span>
+                    {comment.isEdited && <span className="text-xs text-base-content/30">(edited)</span>}
+                </div>
+                {/* Replies */}
+                {comment.replies && comment.replies.length > 0 && (
+                    <div className="ml-4 mt-2 space-y-2">
+                        {comment.replies.map(reply => (
+                            <div key={reply.id} className="flex gap-2">
+                                <div className="avatar flex-shrink-0">
+                                    <div className="w-6 h-6 rounded-full bg-base-300 overflow-hidden relative">
+                                        <Image
+                                            src={reply.user?.image || '/blank_image.png'}
+                                            alt={reply.user?.name || 'User'}
+                                            fill
+                                            sizes="24px"
+                                            className="object-cover"
+                                        />
+                                    </div>
+                                </div>
+                                <div className="flex-1 min-w-0">
+                                    <div className="bg-base-200 rounded-box px-3 py-1.5">
+                                        <div className="flex items-center justify-between">
+                                            <p className="font-bold text-xs">{reply.user?.name || 'Anonymous'}</p>
+                                            {session?.user && parseInt(session.user.id) === reply.userId && (
+                                                <button
+                                                    className="btn btn-ghost btn-xs text-error p-0 h-auto min-h-0"
+                                                    onClick={() => onDelete(reply.id)}
+                                                    title="Delete reply"
+                                                >
+                                                    <IoTrashOutline className="text-sm" />
+                                                </button>
+                                            )}
+                                        </div>
+                                        <p className="text-sm text-base-content">{reply.content}</p>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/components/feed/HelloWorldBanner.js
+++ b/components/feed/HelloWorldBanner.js
@@ -1,0 +1,42 @@
+/* This file is part of the Twisted Artists Guild project.
+
+ Copyright (C) 2025 Twisted Artists Guild
+
+ Licensed under the GNU General Public License v3.0
+ (https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+ This software comes with NO WARRANTY; see the license for details.
+
+ Open source - low-profit - human-first*/
+
+import Link from 'next/link';
+import { IoSparklesOutline, IoCloseOutline, IoFlowerOutline } from 'react-icons/io5';
+
+/**
+ * Shows after a profile or listing is created, linking to the auto-posted hello world.
+ *
+ * @param {Object} props
+ * @param {Object} props.post - The suggested FeedPostSummaryDTO
+ * @param {Function} props.onDismiss - Called when user closes the banner
+ */
+export default function HelloWorldBanner({ post, onDismiss }) {
+    if (!post) return null;
+
+    return (
+        <div className="alert bg-primary/10 border border-primary/20 shadow-sm">
+            <IoSparklesOutline className="text-2xl text-primary" />
+            <div className="flex-1">
+                <p className="font-bold text-sm">Your first post is live on the Bloomscroll!</p>
+                <p className="text-xs text-base-content/60 mt-0.5 line-clamp-2">{post.body_Plaintext || post.body}</p>
+            </div>
+            <div className="flex gap-2">
+                <Link href="/feed" className="btn btn-primary btn-xs gap-1">
+                    <IoFlowerOutline /> View Feed
+                </Link>
+                <button className="btn btn-ghost btn-xs btn-circle" onClick={onDismiss}>
+                    <IoCloseOutline />
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/components/feed/SharePopover.js
+++ b/components/feed/SharePopover.js
@@ -1,0 +1,51 @@
+/* This file is part of the Twisted Artists Guild project.
+
+ Copyright (C) 2025 Twisted Artists Guild
+
+ Licensed under the GNU General Public License v3.0
+ (https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+ This software comes with NO WARRANTY; see the license for details.
+
+ Open source - low-profit - human-first*/
+
+import { useState } from 'react';
+import { IoCopyOutline, IoCheckmarkOutline } from 'react-icons/io5';
+
+export default function SharePopover({ post, onClose }) {
+    const [copied, setCopied] = useState(false);
+    const url = typeof window !== 'undefined' ? window.location.origin + '/feed?post=' + post.feedPostID : '';
+
+    const copyLink = () => {
+        navigator.clipboard.writeText(url);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    const shareExternal = (platform) => {
+        const text = encodeURIComponent(post.body_Plaintext || post.body || 'Check this out on TAG!');
+        const link = encodeURIComponent(url);
+        const urls = {
+            twitter: 'https://twitter.com/intent/tweet?text=' + text + '&url=' + link,
+            facebook: 'https://www.facebook.com/sharer/sharer.php?u=' + link,
+            bluesky: 'https://bsky.app/intent/compose?text=' + text + ' ' + link,
+        };
+        window.open(urls[platform], '_blank', 'width=600,height=400');
+        onClose();
+    };
+
+    return (
+        <div className="absolute right-0 top-8 z-20 card bg-base-100 shadow-xl border border-base-300 w-56">
+            <div className="card-body p-3 gap-2">
+                <p className="text-xs font-bold text-base-content/50 uppercase">Share externally</p>
+                <button className="btn btn-xs btn-ghost justify-start" onClick={() => shareExternal('twitter')}>X / Twitter</button>
+                <button className="btn btn-xs btn-ghost justify-start" onClick={() => shareExternal('facebook')}>Facebook</button>
+                <button className="btn btn-xs btn-ghost justify-start" onClick={() => shareExternal('bluesky')}>Bluesky</button>
+                <div className="divider my-0"></div>
+                <button className="btn btn-xs btn-ghost justify-start gap-1" onClick={copyLink}>
+                    {copied ? <><IoCheckmarkOutline /> Copied!</> : <><IoCopyOutline /> Copy Link</>}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/components/feed/SharedPreview.js
+++ b/components/feed/SharedPreview.js
@@ -1,0 +1,39 @@
+/* This file is part of the Twisted Artists Guild project.
+
+ Copyright (C) 2025 Twisted Artists Guild
+
+ Licensed under the GNU General Public License v3.0
+ (https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+ This software comes with NO WARRANTY; see the license for details.
+
+ Open source - low-profit - human-first*/
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import longDateOptions from '@/utils/longdateoptions';
+
+export default function SharedPreview({ preview }) {
+    if (!preview) return null;
+    return (
+        <Link href={preview.path || '#'} className="block mt-3 rounded-box border border-base-300 bg-base-200 overflow-hidden hover:shadow-md transition-shadow">
+            <div className="flex gap-3 p-3">
+                {preview.image && (
+                    <div className="relative w-16 h-16 rounded overflow-hidden flex-shrink-0 bg-base-300">
+                        <Image src={preview.image} alt={preview.title || ''} fill className="object-cover" />
+                    </div>
+                )}
+                <div className="flex-1 min-w-0">
+                    <p className="font-bold text-sm text-primary truncate">{preview.title || 'Untitled'}</p>
+                    {preview.byline && <p className="text-xs text-base-content/60 truncate">{preview.byline}</p>}
+                    {preview.artistName && <p className="text-xs text-base-content/60">by {preview.artistName}</p>}
+                    {preview.venue && <p className="text-xs text-base-content/60">{preview.venue}</p>}
+                    {preview.price != null && <p className="text-xs font-mono text-success">${Number(preview.price).toFixed(2)}</p>}
+                    {preview.startTime && <p className="text-xs text-base-content/50">{new Date(preview.startTime).toLocaleDateString('en-US', longDateOptions)}</p>}
+                </div>
+                <span className="badge badge-xs badge-outline self-start">{preview.type}</span>
+            </div>
+        </Link>
+    );
+}

--- a/components/moderation/ReportButton.js
+++ b/components/moderation/ReportButton.js
@@ -23,7 +23,7 @@ import { IoFlagOutline, IoClose, IoCheckmarkCircle } from 'react-icons/io5';
  * @param {string} [props.className] - Additional button class overrides
  * @param {"icon"|"text"|"full"} [props.variant] - Button display variant
  */
-export default function ReportButton({ targetType, targetId, className = '', variant = 'icon' }) {
+export default function ReportButton({ targetType, targetId, className = '', variant = 'icon', targetURL = null }) {
     const { data: session } = useSession();
     const router = useRouter();
 
@@ -93,7 +93,7 @@ export default function ReportButton({ targetType, targetId, className = '', var
                 body: JSON.stringify({
                     targetType,
                     targetID: targetId,
-                    targetURL: typeof window !== 'undefined' ? window.location.pathname : null,
+                    targetURL: targetURL || (typeof window !== 'undefined' ? window.location.pathname : null),
                     description: description.trim(),
                     labelIDs: selectedLabels,
                 }),

--- a/hooks/useComments.js
+++ b/hooks/useComments.js
@@ -263,6 +263,5 @@ export const CommentTargetType = {
   BLOG: 3,
   NEWS: 4,
   USER: 5,
-  // Backward-compatible alias used by older call sites.
-  POST: 3,
+  FEED_POST: 6,
 }

--- a/hooks/useImpressions.js
+++ b/hooks/useImpressions.js
@@ -202,5 +202,6 @@ export const ImpressionTargetType = {
   ARTIST: 2,
   COMMENT: 3,
   BLOG: 4,
-  MESSAGE: 5  // NEW: For message impressions
+  MESSAGE: 5,
+  FEED_POST: 6
 }

--- a/hooks/useSuggestHelloWorld.js
+++ b/hooks/useSuggestHelloWorld.js
@@ -1,0 +1,52 @@
+/* This file is part of the Twisted Artists Guild project.
+
+ Copyright (C) 2025 Twisted Artists Guild
+
+ Licensed under the GNU General Public License v3.0
+ (https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+ This software comes with NO WARRANTY; see the license for details.
+
+ Open source - low-profit - human-first*/
+
+import { useState } from 'react';
+
+/**
+ * Hook to suggest and create a quirky "Hello World" first post after profile/listing creation.
+ *
+ * Usage:
+ *   const { suggest, suggesting, suggestedPost, dismissed, dismiss } = useSuggestHelloWorld();
+ *   // After creating an artist: suggest(userId, "Artist", artistId)
+ *   // After creating a listing: suggest(userId, "Listing", listingId)
+ */
+export function useSuggestHelloWorld() {
+    const [suggesting, setSuggesting] = useState(false);
+    const [suggestedPost, setSuggestedPost] = useState(null);
+    const [dismissed, setDismissed] = useState(false);
+
+    const suggest = async (userId, entityType, entityId) => {
+        setSuggesting(true);
+        setDismissed(false);
+        try {
+            const res = await fetch('/api/Feed/suggest-hello-world?userId=' + userId, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ entityType, entityID: entityId }),
+            });
+            if (res.ok) {
+                const post = await res.json();
+                setSuggestedPost(post);
+            }
+        } catch (err) {
+            console.error('Failed to suggest hello world post', err);
+        }
+        setSuggesting(false);
+    };
+
+    const dismiss = () => {
+        setDismissed(true);
+        setSuggestedPost(null);
+    };
+
+    return { suggest, suggesting, suggestedPost, dismissed, dismiss };
+}

--- a/pages/feed/index.js
+++ b/pages/feed/index.js
@@ -1,0 +1,204 @@
+﻿/* This file is part of the Twisted Artists Guild project.
+
+ Copyright (C) 2025 Twisted Artists Guild
+
+ Licensed under the GNU General Public License v3.0
+ (https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+ This software comes with NO WARRANTY; see the license for details.
+
+ Open source - low-profit - human-first*/
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import TagSEO from '@/components/TagSEO';
+import FeedPostCard from '@/components/feed/FeedPostCard';
+import FeedComposer from '@/components/feed/FeedComposer';
+import {
+    IoFlowerOutline,
+    IoTimeOutline,
+    IoTrendingUpOutline,
+    IoArrowBackOutline,
+} from 'react-icons/io5';
+
+const ALGORITHMS = [
+    { key: 'latest', label: 'Latest', icon: IoTimeOutline },
+    { key: 'trending', label: 'Trending', icon: IoTrendingUpOutline },
+];
+
+// ── Single Post View (when ?post=ID is in URL) ───────────────────────
+const SinglePostView = ({ postId }) => {
+    const [post, setPost] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchPost = async () => {
+            try {
+                const res = await fetch('/api/Feed/' + postId);
+                if (res.ok) {
+                    setPost(await res.json());
+                }
+            } catch (err) {
+                console.error('Failed to load post', err);
+            }
+            setLoading(false);
+        };
+        fetchPost();
+    }, [postId]);
+
+    if (loading) {
+        return <div className="flex justify-center py-12"><span className="loading loading-spinner loading-lg text-primary"></span></div>;
+    }
+
+    if (!post) {
+        return (
+            <div className="card bg-base-100 border border-base-300 shadow-sm">
+                <div className="card-body items-center text-center py-12">
+                    <IoFlowerOutline className="text-5xl text-base-content/20 mb-3" />
+                    <p className="text-base-content/50 text-lg">Post not found</p>
+                    <Link href="/feed" className="btn btn-primary btn-sm mt-4">Back to Feed</Link>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <Link href="/feed" className="btn btn-ghost btn-sm gap-1">
+                <IoArrowBackOutline /> Back to Bloomscroll
+            </Link>
+            <FeedPostCard post={post} />
+        </div>
+    );
+};
+
+// ═════════════════════════════════════════════════════════════════════
+// ── Main Feed Page ──────────────────────────────────────────────────
+// ═════════════════════════════════════════════════════════════════════
+export default function BloomscrollFeed() {
+    const { data: session } = useSession();
+    const router = useRouter();
+    const { post: singlePostId } = router.query;
+
+    const [posts, setPosts] = useState([]);
+    const [page, setPage] = useState(1);
+    const [totalPages, setTotalPages] = useState(1);
+    const [loading, setLoading] = useState(true);
+    const [loadingMore, setLoadingMore] = useState(false);
+    const [algorithm, setAlgorithm] = useState('latest');
+
+    const observerRef = useRef(null);
+
+    const fetchPosts = useCallback(async (pageNum, append = false) => {
+        if (append) setLoadingMore(true);
+        else setLoading(true);
+
+        try {
+            const params = new URLSearchParams({ page: pageNum, pageSize: 20, algorithm });
+            const res = await fetch('/api/Feed?' + params.toString());
+            if (res.ok) {
+                const data = await res.json();
+                setPosts(prev => append ? [...prev, ...(data.items || [])] : (data.items || []));
+                setTotalPages(data.totalPages || 1);
+            }
+        } catch (err) {
+            console.error('Failed to load feed', err);
+        }
+        setLoading(false);
+        setLoadingMore(false);
+    }, [algorithm]);
+
+    useEffect(() => {
+        if (!singlePostId) {
+            setPage(1);
+            fetchPosts(1, false);
+        }
+    }, [fetchPosts, singlePostId]);
+
+    // Infinite scroll
+    useEffect(() => {
+        if (singlePostId || !observerRef.current) return;
+        const observer = new IntersectionObserver(entries => {
+            if (entries[0].isIntersecting && !loadingMore && page < totalPages) {
+                const nextPage = page + 1;
+                setPage(nextPage);
+                fetchPosts(nextPage, true);
+            }
+        }, { threshold: 0.5 });
+        observer.observe(observerRef.current);
+        return () => observer.disconnect();
+    }, [page, totalPages, loadingMore, fetchPosts, singlePostId]);
+
+    const handlePostCreated = () => {
+        setPage(1);
+        fetchPosts(1, false);
+    };
+
+    // If ?post=ID is in URL, show single post view
+    if (singlePostId) {
+        return (
+            <div className="min-h-screen bg-base-200">
+                <TagSEO metadataProp={{ title: "Post - Bloomscroll", description: "A post on TAG Bloomscroll" }} canonicalSlug={'feed?post=' + singlePostId} />
+                <div className="container mx-auto px-4 py-8 max-w-2xl">
+                    <SinglePostView postId={singlePostId} />
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen bg-base-200">
+            <TagSEO metadataProp={{ title: "Bloomscroll", description: "Your creative social feed on TAG" }} canonicalSlug="feed" />
+
+            <div className="container mx-auto px-4 py-8 max-w-2xl">
+                {/* Header */}
+                <div className="flex items-center justify-between mb-6">
+                    <h1 className="text-3xl font-extrabold text-primary flex items-center gap-2">
+                        <IoFlowerOutline /> Bloomscroll
+                    </h1>
+                    <div className="flex gap-1">
+                        {ALGORITHMS.map(algo => (
+                            <button
+                                key={algo.key}
+                                className={'btn btn-sm gap-1 ' + (algorithm === algo.key ? 'btn-primary' : 'btn-ghost')}
+                                onClick={() => setAlgorithm(algo.key)}
+                            >
+                                <algo.icon /> {algo.label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Compose */}
+                {session?.user && (
+                    <FeedComposer session={session} onPostCreated={handlePostCreated} />
+                )}
+
+                {/* Feed Posts */}
+                <div className="space-y-4">
+                    {loading ? (
+                        <div className="flex justify-center py-12"><span className="loading loading-spinner loading-lg text-primary"></span></div>
+                    ) : posts.length === 0 ? (
+                        <div className="card bg-base-100 border border-base-300 shadow-sm">
+                            <div className="card-body items-center text-center py-12">
+                                <IoFlowerOutline className="text-5xl text-base-content/20 mb-3" />
+                                <p className="text-base-content/50 text-lg">The feed is quiet... be the first to bloom!</p>
+                            </div>
+                        </div>
+                    ) : posts.map(post => (
+                        <FeedPostCard key={post.feedPostID} post={post} />
+                    ))}
+
+                    {/* Infinite scroll sentinel */}
+                    {page < totalPages && (
+                        <div ref={observerRef} className="flex justify-center py-4">
+                            {loadingMore && <span className="loading loading-spinner text-primary"></span>}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/pages/portal/staff/moderation/index.js
+++ b/pages/portal/staff/moderation/index.js
@@ -30,7 +30,7 @@ import {
 } from 'react-icons/io5';
 
 const STATUS_OPTIONS = ['New', 'UnderReview', 'Resolved', 'Dismissed'];
-const TARGET_TYPES = ['Listing', 'Artist', 'User', 'Comment', 'Message', 'Blog', 'Event'];
+const TARGET_TYPES = ['Listing', 'Artist', 'User', 'Comment', 'Message', 'Blog', 'Event', 'FeedPost'];
 const PRIORITY_LABELS = { 0: 'Low', 1: 'Normal', 2: 'High', 3: 'Critical' };
 const PRIORITY_COLORS = { 0: 'badge-ghost', 1: 'badge-info', 2: 'badge-warning', 3: 'badge-error' };
 const STATUS_COLORS = { New: 'badge-warning', UnderReview: 'badge-info', Resolved: 'badge-success', Dismissed: 'badge-ghost' };


### PR DESCRIPTION
# Bloomscroll Social Feed

## Description

Introduces Bloomscroll — a dedicated social media feed page where users, artists, vendors, venues, and events can post updates, share content, and engage through reactions and comments. Includes external sharing to X/Twitter, Facebook, and Bluesky, plus a quirky auto-generated "Hello World" first post system for new profiles and listings.

---

## What's Included

### Backend — New Models

- `FeedPost` — Social feed post entity supporting general posts and shared entity posts (Listing, Artist, Event, Vendor, Venue)
- `FeedPostImpression` — Reactions/impressions linked to `PrimaryImpression` system

### Backend — New DTOs

- `CreateFeedPostDTO` — Post creation payload
- `FeedPostSummaryDTO` — Rich response with author info, shared entity preview, comment/reaction counts
- `SuggestHelloWorldDTO` — Trigger for auto-generated first post

### Backend — New Controller

- `FeedController` with endpoints:
  - `GET /api/Feed` — Paginated feed with algorithm sorting (`latest`, `trending`), entity/user filtering
  - `GET /api/Feed/{id}` — Single post detail
  - `POST /api/Feed?authorUserId={id}` — Create a post
  - `DELETE /api/Feed/{id}?userId={id}` — Soft-delete own post
  - `POST /api/Feed/suggest-hello-world?userId={id}` — Generate a quirky first post (10 random variants)

### Backend — Enum Updates

- `CommentTargetType` — Added `FeedPost = 6` to support comments on feed posts
- `TargetType` (Impressions) — Added `FeedPost = 6` to support reactions on feed posts

### Backend — Impression Controller Updates

- Added `FeedPost` case to `GetPrimaryImpressions` endpoint for fetching reaction counts
- Added `FeedPost` case to `ReactToTarget` endpoint for toggling reactions

### Backend — Content Report Integration

- Added `FeedPost` case to `SetModerationBlocked` in `ContentReportController`
- Added `FeedPost` case to `ResolveContentOwnerUserId` for suspend action
- Added `FeedPost` to moderation dashboard `TARGET_TYPES` filter

### Frontend — New Components (Modular Structure)

| File | Purpose |
|---|---|
| `components/feed/FeedPostCard.js` | Post card — author row, body, image, shared preview, reactions, comments, share, delete own post |
| `components/feed/FeedPostComments.js` | Comment input, list with replies, delete own comments. Uses `CommentItem` sub-component |
| `components/feed/FeedComposer.js` | Post creation form with share type selector (General, Listing, Artist, Event) |
| `components/feed/SharedPreview.js` | Inline preview card for shared entities (listing cover, artist profile, event details) |
| `components/feed/SharePopover.js` | External share dropdown (X/Twitter, Facebook, Bluesky, Copy Link) |
| `components/feed/HelloWorldBanner.js` | Success banner shown after auto-posting first post, links to feed |
| `hooks/useSuggestHelloWorld.js` | Hook to trigger hello world post after entity creation |
| `pages/feed/index.js` | Main page — algorithm switcher, infinite scroll, compose, single post view via `?post=ID` |

### Frontend — Key Features

- **Infinite scroll** with IntersectionObserver for seamless feed loading
- **Algorithm switcher** — Latest (newest first) and Trending (most reactions first)
- **Single post view** — When shared URL `?post=ID` is opened, shows only that specific post with a "Back to Bloomscroll" link
- **External sharing** — Share to X/Twitter, Facebook, Bluesky with post content pre-filled, or copy direct link
- **Reactions** — Full impression/reaction system using existing `useImpressions` hook with new `FEED_POST` target type
- **Comments** — Inline comment section with `useCommentCount` (always loaded) for badge count and `useComments` (lazy loaded on expand) for full list
- **Delete own post** — Trash icon visible only to post author, confirm dialog, post disappears on success
- **Delete own comments** — Trash icon on comments/replies owned by current user
- **Content reporting** — Report button on each post with specific post URL (`/feed?post=ID`) passed to report

### Frontend — Report Button Enhancement

- `ReportButton` now accepts optional `targetURL` prop to override `window.location.pathname`
- Feed posts pass `/feed?post={id}` as `targetURL` so reports link to the specific post, not the generic `/feed` page

### Hello World Quips (10 random variants)

Auto-generated posts inject the entity name, e.g.:

> 🎭 **Twisted Canvas Studio** enters stage left. The audience gasps. A single rose is thrown. This is our origin story.

> 🚀 Houston, **Neon Dreams Collection** has launched. Trajectory: straight into your bloomscroll. ETA: right now.

> 🔮 The algorithm whispered: "**Midnight Sculptures** is about to do something cool." We don't know what yet. But stay tuned.

### API Endpoints

| Method | Endpoint | Purpose |
|---|---|---|
| GET | `/api/Feed` | Paginated feed (`algorithm`, `entityType`, `entityId`, `userId`, `page`, `pageSize`) |
| GET | `/api/Feed/{id}` | Single post detail |
| POST | `/api/Feed?authorUserId={id}` | Create a post |
| DELETE | `/api/Feed/{id}?userId={id}` | Soft-delete own post |
| POST | `/api/Feed/suggest-hello-world?userId={id}` | Generate quirky first post |

---

## How to Test

1. Navigate to `/feed`
2. Create a post — verify it appears in the feed
3. Click reactions — verify they toggle
4. Click comments — verify count loads, add a comment, delete it
5. Click Share — verify X/Twitter/Facebook/Bluesky links open with correct post URL
6. Open a shared URL like `/feed?post=1` — verify only that post shows
7. Delete own post — verify it disappears
8. Report a post — verify report modal opens and `targetURL` is `/feed?post={id}`
9. Switch between Latest/Trending algorithms